### PR TITLE
Adding Fix to Disable Rules

### DIFF
--- a/randomizer.html
+++ b/randomizer.html
@@ -15,7 +15,7 @@
       <p id="splashTextDisplay" class="splash-text"></p>
       <img src="images/logo.png" alt="RandomizerLogo" class="center" id="pageLogo">
       <div class="center-text">
-        eldri7ch
+        By eldri7ch
         <span class="tooltip-wrapper">
           <span class="tooltip-indicator">?</span>
           <span class="tooltip hidden">

--- a/src/browser.js
+++ b/src/browser.js
@@ -688,27 +688,12 @@
         // Normal boolean behavior
         el.checked = !!presetValue;
       });
-
-      // HARD OVERRIDE: presets cannot enable singleHitGearMode
-      // el.checked = false; (if you want to enforce this)
-
-      // Compatibility disables still apply
-      DISABLE_RULES.forEach(rule => {
-        if (rule.ids.includes(presetId)) {
-          rule.elems.forEach(key => {
-            const el = elems[key];
-            if (!el) return;
-            const wasChecked = el.checked;
-            el.disabled = true;
-            el.checked = wasChecked;
-          });
-        }
-      });
     }
 
     enforceGoalCompatibility(preset.id);
     applyOptions(options, preset.id);
     relicLocationsExtensionChange();
+
     const TOURNAMENT_LOCKED = [
       "accessibilityPatches",
       "antiFreezeMode",
@@ -783,6 +768,18 @@
       allRadios.forEach(r => r.disabled = false);
     }
     ChangeHandlers.tournamentModeChange();
+    DISABLE_RULES.forEach(rule => {
+      if (rule.ids.includes(preset.id)) {
+        rule.elems.forEach(key => {
+          const el = elems[key];
+          if (!el) return;
+
+          const wasChecked = el.checked;
+          el.disabled = true;
+          el.checked = wasChecked;
+        });
+      }
+    });
   }
 
   function complexityChange() {

--- a/src/constants.js
+++ b/src/constants.js
@@ -1889,6 +1889,7 @@
     "For Shakey!",
     "Barley Teas!",
     "But DerDrach has full-cleared second castle!",
+    "2020 Tournament Champion Dr4gonBlitz!",
     "Spring Tournament 2022 Champion JupiterClimb",
     "Spring Tournament 2023 Champion Dr4gonBlitz!",
     "Spring Tournament 2024 Champion the__swarm!",

--- a/src/constants.js
+++ b/src/constants.js
@@ -1904,6 +1904,12 @@
     "Made of 28 percent spaghetti!",
     "Stages, and overlays, and entities, oh my!",
     "Happy 40th, Castlevania!",
+    "0 teraFLOPS!",
+    "Play nuts outside!",
+    "We have phones!",
+    "It just works!",
+    "Do the math!",
+    "Definitely real!",
     "BUFFER DO NOT DELETE!"
   ]
 


### PR DESCRIPTION
Fixes the changes that make the Tournament disables override preset disables. now non-tournament presets will have the incompatible options disabled correctly. Also add the "By " that was removed when Mouse removed his name from the randomizer.html page.