### PR TITLE
Prototyping ReverseCastleTeleporterRando

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -1210,6 +1210,46 @@
     }
   ]
 
+  const reverseTeleporterData = [
+	{
+	  stage: 0x2B,	// Vanilla
+	  room: 0,
+	  xPos: 0,
+	  yPos: 0,
+	  xPosWarp: 0,
+	  yPosWarp: 0,
+	  tsLba: 0,
+	  tileofs: 0,
+	  tileval: 0,
+	  mapaddr: 0,
+	  mapmask: 0
+	}, {
+	  stage: 0x21,		// Stage Number
+	  room: 1,			// Room Number in Stage
+	  xPos: 0x27e,		// X Position Alucard to Trigger Warp
+	  yPos: 0x32A7,		// Y Position
+	  xPosWarp: 0x80,	// X Position for Destination, Reverse Castle flips these around
+	  yPosWarp: 0x80,	// based on room size as these must be set correctly.
+	  tsLba: 0x8B26,	// LBA of the tileset file for the Stage
+	  tileofs: 0x505E786,	// BIN Address of Tile to Change to mark the teleporter pad
+	  tileval: 0x0303,		// the Value to Write, if greater than 0xFFFF it will write two tiles
+	  mapaddr: 0,	// RAM Address of map cell
+	  mapmask: 0	// Bitmask to apply
+	}, {
+	  stage: 0x21,
+	  room: 1,
+	  xPos: 0x27e,
+	  yPos: 0x80,
+	  xPosWarp: 0x27e,
+	  yPosWarp: 0x80,
+	  tsLba: 0x8B26,
+	  tileofs: 0,	// BIN Address of Tile to Change
+	  tileval: 0,
+	  mapaddr: 0,	// RAM Address of map cell
+	  mapmask: 0	// Bitmask to apply
+	}
+  ]
+  
   // #region Start Room Rando
   // This data is provided for the starting room randomizer. Writes are used
   // for writing where Alucard goes. The stage is used for detecting when we

--- a/src/util.js
+++ b/src/util.js
@@ -8085,6 +8085,59 @@
     return data
   }
 
+  // prototyping randomizing reverse castle teleporter by MottZilla
+  function applyReverseCastleTeleporterRandoPatches(rng) {
+    const reverseTeleporterData = constants.reverseTeleporterData
+    const data = new checked()
+	let randTp
+	let offset
+	
+	// debug
+	console.log("applyReverseCastleTeleporterRandoPatches executing")
+	
+    // Select random Tp Location
+    randTp = Math.floor(rng() * Math.floor(reverseTeleporterData.length))
+	
+	// Testing, remove later
+	randTp = 1
+	
+	// If Vanilla then we don't write anything.
+	if(reverseTeleporterData[randTp].stage == 0x2B)
+	{
+		return data
+	}
+
+	// Do writes for updating activation and updating destination
+	data.writeShort(0x125C2C, reverseTeleporterData[randTp].stage)	// stage Trigger
+	data.writeShort(0x109294, reverseTeleporterData[randTp].stage)	// stage Dest
+	data.writeShort(0x125C50, 0x10000 - reverseTeleporterData[randTp].xPos)	// Trigger
+	data.writeShort(0x125C84, 0x10000 - reverseTeleporterData[randTp].yPos)	// Trigger
+	offset = 0xAE5B6
+	offset = data.writeShort(offset, reverseTeleporterData[randTp].xPosWarp)	// Dest
+	offset = data.writeShort(offset, reverseTeleporterData[randTp].yPosWarp)	// Dest
+	offset = data.writeShort(offset, reverseTeleporterData[randTp].room * 8)	// Dest
+	
+	data.writeShort(0xB084C,reverseTeleporterData[randTp].tsLba)	// Tileset update
+	
+	// Optional Tile update to mark the location visually
+	if(reverseTeleporterData[randTp].tileofs > 0)
+	{
+		if(reverseTeleporterData[randTp].tileofs > 0xFFFF)
+		{
+			data.writeWord(reverseTeleporterData[randTp].tileofs, reverseTeleporterData[randTp].tileval)
+		}
+		else
+		{
+			data.writeShort(reverseTeleporterData[randTp].tileofs, reverseTeleporterData[randTp].tileval)
+		}
+	}
+	
+	// todo: record the location for the in game map to be used by the rando master function
+	// this will let us reveal it for random 2nd castle start.
+	
+    return data
+  }
+	
   function applyStartRoomRandoPatches(rng, castleFlag) {
     const castleOneRoomData = constants.startRoomData.filter(function(room) {
       return room.stage < 0x20


### PR DESCRIPTION
This contains the base structure for randomizing the destination of the reverse castle teleporter. It has one location currently in Reverse Outer Wall. 

Todo: Add an option to the GUI and Command Line for it. Add more locations. 

Each location will need various values recorded such as the Stage, Room, X&Y position for activation, X&Y position for destination, and Tileset LBA for tileset graphics loading. Optionally a tile address and tile value to make a change that makes the position of the teleporter visible. Also adding a ram address and bitmask for revealing the map tile which would need to be grabbed in the master rando function so it could be revealed. Probably should store the address somewhere fixed/easy.