### PR TITLE
Add navbar stylesheet to mapcompare.html

### DIFF
--- a/mapcompare.html
+++ b/mapcompare.html
@@ -7,7 +7,7 @@
     <title>Map Tool</title>
     <link rel="stylesheet" href="/styles/main.css">
     <link rel="icon" href="images/favicon.ico">
-
+    <link rel="stylesheet" href="/styles/navbar.css">
 </head>
 
 <body>


### PR DESCRIPTION
Include a <link> to /styles/navbar.css in the head of mapcompare.html so the site's navigation styles are loaded. Minor whitespace cleanup in the head section.